### PR TITLE
Remove bower_components from /public on production during meteor bundle

### DIFF
--- a/vulcanize.js
+++ b/vulcanize.js
@@ -1,7 +1,9 @@
 var vulcan = Npm.require('vulcanize');
 var _ = Npm.require('underscore');
 var fs = Npm.require('fs');
+var path = Npm.require('path');
 var rootPath = process.env.VULCANIZE_PATH || 'public';
+rootPath = path.resolve(rootPath);
 
 var handler = function(compileStep) {
   var importsHtml = compileStep.read().toString('utf8');


### PR DESCRIPTION
After project been vulcanized, we don't need bower_components in public folder anymore.
Lets remove it for production during meteor bundle.
Closes #3 