### PR TITLE
Feature detection for the webcomponents polyfill

### DIFF
--- a/vulcanize.js
+++ b/vulcanize.js
@@ -27,7 +27,17 @@ function log() {
  * Get script tag with specified path.
  */
 function scriptTag(path) {
-  return '<script src="' + path + '"></script>';
+ var script = "<script>\
+  var webComponentsSupported = ('registerElement' in document\
+   && 'import' in document.createElement('link')\
+   && 'content' in document.createElement('template'));\
+  if (!webComponentsSupported) {\
+     var script = document.createElement('script');\
+     script.src = '"+path+"';\
+     document.head.appendChild(script);\
+  }\
+  </script>";
+return script;
 }
 
 /**


### PR DESCRIPTION
only load the polyfill if the browser doesn't already have native support for it (i.e. Chrome)
